### PR TITLE
Fix apiGroup for manager-role rule

### DIFF
--- a/config/crd/bases/infrastructure.crit.sh_dockerinfrastructureproviders.yaml
+++ b/config/crd/bases/infrastructure.crit.sh_dockerinfrastructureproviders.yaml
@@ -29,18 +29,24 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: DockerInfrastructureProvider is the Schema for the infrastructureproviders API
+      description: DockerInfrastructureProvider is the Schema for the infrastructureproviders
+        API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
-          description: DockerInfrastructureProviderSpec defines the desired state of DockerInfrastructureProvider
+          description: DockerInfrastructureProviderSpec defines the desired state
+            of DockerInfrastructureProvider
           properties:
             defaultImage:
               type: string
@@ -48,7 +54,8 @@ spec:
           - defaultImage
           type: object
         status:
-          description: InfrastructureProviderStatus defines the observed state of DockerInfrastructureProvider
+          description: InfrastructureProviderStatus defines the observed state of
+            DockerInfrastructureProvider
           properties:
             lastUpdated:
               format: date-time

--- a/config/crd/bases/infrastructure.crit.sh_dockermachines.yaml
+++ b/config/crd/bases/infrastructure.crit.sh_dockermachines.yaml
@@ -24,10 +24,14 @@ spec:
       description: DockerMachine is the Schema for the dockermachines API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -51,10 +55,34 @@ spec:
           description: DockerMachineStatus defines the observed state of DockerMachine
           properties:
             failureMessage:
-              description: "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+              description: "FailureMessage will be set in the event that there is
+                a terminal problem reconciling the Machine and will contain a more
+                verbose string suitable for logging and human consumption. \n This
+                field should not be set for transitive errors that a controller faces
+                that are expected to be fixed automatically over time (like service
+                outages), but instead indicate that something is fundamentally wrong
+                with the Machine's spec or the configuration of the controller, and
+                that manual intervention is required. Examples of terminal errors
+                would be invalid combinations of settings in the spec, values that
+                are unsupported by the controller, or the responsible controller itself
+                being critically misconfigured. \n Any transient errors that occur
+                during the reconciliation of Machines can be added as events to the
+                Machine object and/or logged in the controller's output."
               type: string
             failureReason:
-              description: "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+              description: "FailureReason will be set in the event that there is a
+                terminal problem reconciling the Machine and will contain a succinct
+                value suitable for machine interpretation. \n This field should not
+                be set for transitive errors that a controller faces that are expected
+                to be fixed automatically over time (like service outages), but instead
+                indicate that something is fundamentally wrong with the Machine's
+                spec or the configuration of the controller, and that manual intervention
+                is required. Examples of terminal errors would be invalid combinations
+                of settings in the spec, values that are unsupported by the controller,
+                or the responsible controller itself being critically misconfigured.
+                \n Any transient errors that occur during the reconciliation of Machines
+                can be added as events to the Machine object and/or logged in the
+                controller's output."
               type: string
             ready:
               type: boolean

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,7 +6,9 @@ metadata:
   creationTimestamp: null
   name: manager-role
 rules:
-- resources:
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - '*'

--- a/controllers/dockerinfrastructureprovider_controller.go
+++ b/controllers/dockerinfrastructureprovider_controller.go
@@ -59,7 +59,7 @@ func (r *DockerInfrastructureProviderReconciler) SetupWithManager(mgr ctrl.Manag
 // +kubebuilder:rbac:groups=infrastructure.crit.sh,resources=dockerinfrastructureproviders,verbs=get;list;watch
 // +kubebuilder:rbac:groups=infrastructure.crit.sh,resources=dockerinfrastructureproviders/status,verbs=create;update
 // +kubebuilder:rbac:groups=machine.crit.sh,resources=infrastructureproviders;infrastructureproviders/status,verbs=get;list;watch
-// +kubebuilder:rbac:groups=,resources=secrets,verbs=*
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=*
 
 func (r *DockerInfrastructureProviderReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx := context.Background()


### PR DESCRIPTION
kubebuilder/controller-gen left out the apiGroup in the generated role because it was not quoted.